### PR TITLE
Add URL Input Support for Fact-Checking

### DIFF
--- a/utils/fetch_url.py
+++ b/utils/fetch_url.py
@@ -1,0 +1,16 @@
+import requests
+from bs4 import BeautifulSoup
+
+def get_text_from_url(url):
+    """
+    Fetches and returns text content from a given URL.
+    """
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        paragraphs = soup.find_all('p')
+        text = " ".join([p.get_text() for p in paragraphs])
+        return text
+    except Exception as e:
+        return f"Error fetching URL: {e}"


### PR DESCRIPTION
This PR adds the ability for the FactChecker API to accept a URL in addition to plain text.

Changes included:

Added utils/fetch_url.py to fetch and extract text content from web pages.

Updated /predict and /predict_all endpoints to handle an optional "url" key.

If a URL is provided, the text is fetched and passed to the fact-checker; otherwise, text input is used.

Preserves existing prediction logic and backward compatibility.

How to test:

Run the Flask app locally:

python app.py


Send a POST request with JSON body:

Text input: {"text": "Some news text"}

URL input: {"url": "https://example.com/article"}

Verify JSON response contains prediction, confidence, message, and analysis.

Benefit:

Allows users to quickly check the authenticity of online articles via URL.

Enhances usability and lays the groundwork for future front-end improvements.